### PR TITLE
Fix to respect user provided s3 source and destination path prefixes

### DIFF
--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Tuple
 
 from datadog_sync.constants import (
     Origin,
-    AWS_BUCKET_KEY_PREFIX_DESTINATION,
-    AWS_BUCKET_KEY_PREFIX_SOURCE,
     DESTINATION_PATH_DEFAULT,
     DESTINATION_PATH_PARAM,
     SOURCE_PATH_DEFAULT,
@@ -21,16 +19,14 @@ from datadog_sync.utils.storage.storage_types import StorageType
 
 class State:
     def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
+        source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+        destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
         if type_ == StorageType.LOCAL_FILE:
-            source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
-            destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
             self._storage: BaseStorage = LocalFile(
                 source_resources_path=source_resources_path,
                 destination_resources_path=destination_resources_path,
             )
         elif type_ == StorageType.AWS_S3_BUCKET:
-            source_resources_path = kwargs.get(AWS_BUCKET_KEY_PREFIX_SOURCE, SOURCE_PATH_DEFAULT)
-            destination_resources_path = kwargs.get(AWS_BUCKET_KEY_PREFIX_DESTINATION, DESTINATION_PATH_DEFAULT)
             config = kwargs.get("config", {})
             if not config:
                 raise ValueError("AWS configuration not found")


### PR DESCRIPTION
### What does this PR do?
Fixes s3 bucket source and destination path prefixes in case of user provides

### Description of the Change
User provided `aws-bucket-key-prefix-source` and `aws-bucket-key-prefix-destination` were not respected instead default paths were taken. This MR fixes the issue

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
